### PR TITLE
Add volunteer registration script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
 # alask
 Internal Auditor ISO 45001:2018
+
+## Volunteer Registration App
+
+This repository includes a small command line application to register volunteers. The script is located in `volunteer_app/register.py` and stores data in `volunteer_app/volunteers.csv`.
+
+### Usage
+
+Run the script using Python 3:
+
+```bash
+python3 volunteer_app/register.py
+```
+
+You will be prompted to add new volunteers or list existing ones.
+
+## Volunteer System CLI
+
+A more complete console application is available in `volunteer_app/main.py`. It supports OTP based registration and login, basic program management and records actions in an audit trail using SQLite.
+
+Initialize the database and start the application:
+
+```bash
+python3 -m volunteer_app.main
+```

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,25 @@
+import sys, pathlib; sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+import os
+import sqlite3
+from volunteer_app.db import init_db, DB_PATH
+
+
+def test_init_db(tmp_path):
+    db_file = tmp_path / "test.db"
+    init_db(db_file)
+    conn = sqlite3.connect(db_file)
+    cur = conn.cursor()
+    cur.execute("SELECT name FROM sqlite_master WHERE type='table'")
+    tables = {row[0] for row in cur.fetchall()}
+    expected = {
+        'users',
+        'programs',
+        'attendance',
+        'reflections',
+        'badges',
+        'audit_trail'
+    }
+    assert expected.issubset(tables)
+    conn.close()
+
+

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,12 @@
+import sys, pathlib; sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+from volunteer_app.main import generate_otp
+
+
+def test_generate_otp_length():
+    otp = generate_otp()
+    assert len(otp) == 6
+    assert otp.isdigit()
+
+
+
+

--- a/volunteer_app/db.py
+++ b/volunteer_app/db.py
@@ -1,0 +1,81 @@
+import sqlite3
+from pathlib import Path
+
+DB_PATH = Path(__file__).resolve().parent / "volunteers.db"
+
+SCHEMA = [
+    """
+    CREATE TABLE IF NOT EXISTS users (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT NOT NULL,
+        email TEXT UNIQUE NOT NULL,
+        phone TEXT,
+        age INTEGER,
+        location TEXT,
+        community TEXT,
+        role TEXT DEFAULT 'participant',
+        verified INTEGER DEFAULT 0,
+        otp_code TEXT
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS programs (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT NOT NULL,
+        description TEXT
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS attendance (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id INTEGER NOT NULL,
+        program_id INTEGER NOT NULL,
+        check_in TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        FOREIGN KEY(user_id) REFERENCES users(id),
+        FOREIGN KEY(program_id) REFERENCES programs(id)
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS reflections (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id INTEGER NOT NULL,
+        program_id INTEGER NOT NULL,
+        text TEXT,
+        sentiment TEXT,
+        FOREIGN KEY(user_id) REFERENCES users(id),
+        FOREIGN KEY(program_id) REFERENCES programs(id)
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS badges (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id INTEGER NOT NULL,
+        name TEXT,
+        description TEXT,
+        FOREIGN KEY(user_id) REFERENCES users(id)
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS audit_trail (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id INTEGER,
+        action TEXT NOT NULL,
+        timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        FOREIGN KEY(user_id) REFERENCES users(id)
+    )
+    """
+]
+
+
+def connect(path: Path = DB_PATH):
+    return sqlite3.connect(path)
+
+
+def init_db(path: Path = DB_PATH):
+    conn = connect(path)
+    cur = conn.cursor()
+    for statement in SCHEMA:
+        cur.execute(statement)
+    conn.commit()
+    conn.close()
+

--- a/volunteer_app/main.py
+++ b/volunteer_app/main.py
@@ -1,0 +1,201 @@
+import random
+from getpass import getpass
+
+from .db import connect, init_db, DB_PATH
+
+
+def generate_otp() -> str:
+    return f"{random.randint(100000, 999999)}"
+
+
+def register():
+    conn = connect()
+    cur = conn.cursor()
+    name = input("Name: ").strip()
+    email = input("Email: ").strip()
+    phone = input("Phone: ").strip()
+    age = input("Age: ").strip()
+    location = input("Location: ").strip()
+    community = input("Community: ").strip()
+
+    otp = generate_otp()
+    print(f"OTP sent (simulated): {otp}")
+    user_input = getpass("Enter OTP: ")
+    if user_input != otp:
+        print("OTP mismatch. Registration aborted.")
+        return
+
+    cur.execute(
+        """
+        INSERT INTO users (name, email, phone, age, location, community, verified)
+        VALUES (?, ?, ?, ?, ?, ?, 1)
+        """,
+        (name, email, phone, age, location, community),
+    )
+    conn.commit()
+    cur.execute(
+        "INSERT INTO audit_trail (user_id, action) VALUES (?, ?)",
+        (cur.lastrowid, "register"),
+    )
+    conn.commit()
+    conn.close()
+    print("Registration successful.")
+
+
+def login(role="participant"):
+    conn = connect()
+    cur = conn.cursor()
+    email = input("Email: ").strip()
+    cur.execute("SELECT id FROM users WHERE email=? AND role=?", (email, role))
+    row = cur.fetchone()
+    if not row:
+        print("User not found or role mismatch.")
+        return None
+    user_id = row[0]
+    otp = generate_otp()
+    print(f"OTP sent (simulated): {otp}")
+    user_input = getpass("Enter OTP: ")
+    if user_input != otp:
+        print("OTP mismatch.")
+        return None
+    cur.execute(
+        "INSERT INTO audit_trail (user_id, action) VALUES (?, ?)", (user_id, "login")
+    )
+    conn.commit()
+    conn.close()
+    return user_id
+
+
+def list_programs():
+    conn = connect()
+    cur = conn.cursor()
+    cur.execute("SELECT id, name, description FROM programs")
+    programs = cur.fetchall()
+    conn.close()
+    if not programs:
+        print("No programs available.")
+        return []
+    for p in programs:
+        print(f"{p[0]}. {p[1]} - {p[2]}")
+    return programs
+
+
+def join_program(user_id: int):
+    programs = list_programs()
+    if not programs:
+        return
+    choice = input("Program ID to join: ").strip()
+    conn = connect()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO attendance (user_id, program_id) VALUES (?, ?)", (user_id, choice)
+    )
+    cur.execute(
+        "INSERT INTO audit_trail (user_id, action) VALUES (?, ?)",
+        (user_id, f"join_program:{choice}"),
+    )
+    conn.commit()
+    conn.close()
+    print("Attendance recorded.")
+
+
+def add_reflection(user_id: int):
+    programs = list_programs()
+    if not programs:
+        return
+    choice = input("Program ID for reflection: ").strip()
+    text = input("Reflection text: ")
+    sentiment = "positive" if "good" in text.lower() else "neutral"
+    conn = connect()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO reflections (user_id, program_id, text, sentiment) VALUES (?, ?, ?, ?)",
+        (user_id, choice, text, sentiment),
+    )
+    cur.execute(
+        "INSERT INTO audit_trail (user_id, action) VALUES (?, ?)",
+        (user_id, f"reflect:{choice}"),
+    )
+    conn.commit()
+    conn.close()
+    print("Reflection saved.")
+
+
+def participant_menu(user_id: int):
+    while True:
+        print("\nParticipant Menu")
+        print("1. View programs")
+        print("2. Join program")
+        print("3. Add reflection")
+        print("4. Logout")
+        choice = input("Choose: ").strip()
+        if choice == "1":
+            list_programs()
+        elif choice == "2":
+            join_program(user_id)
+        elif choice == "3":
+            add_reflection(user_id)
+        elif choice == "4":
+            break
+        else:
+            print("Invalid choice")
+
+
+def admin_menu(user_id: int):
+    conn = connect()
+    cur = conn.cursor()
+    while True:
+        print("\nAdmin Menu")
+        print("1. Add program")
+        print("2. List participants")
+        print("3. Logout")
+        choice = input("Choose: ").strip()
+        if choice == "1":
+            name = input("Program name: ")
+            desc = input("Description: ")
+            cur.execute(
+                "INSERT INTO programs (name, description) VALUES (?, ?)", (name, desc)
+            )
+            cur.execute(
+                "INSERT INTO audit_trail (user_id, action) VALUES (?, ?)",
+                (user_id, f"add_program:{name}"),
+            )
+            conn.commit()
+        elif choice == "2":
+            cur.execute("SELECT id, name, email FROM users WHERE role='participant'")
+            for row in cur.fetchall():
+                print(f"{row[0]} {row[1]} - {row[2]}")
+        elif choice == "3":
+            break
+        else:
+            print("Invalid choice")
+    conn.close()
+
+
+def main():
+    init_db()
+    while True:
+        print("\nWelcome")
+        print("1. Register participant")
+        print("2. Participant login")
+        print("3. Admin login")
+        print("4. Exit")
+        choice = input("Choose: ").strip()
+        if choice == "1":
+            register()
+        elif choice == "2":
+            user_id = login("participant")
+            if user_id:
+                participant_menu(user_id)
+        elif choice == "3":
+            user_id = login("admin")
+            if user_id:
+                admin_menu(user_id)
+        elif choice == "4":
+            break
+        else:
+            print("Invalid choice")
+
+
+if __name__ == "__main__":
+    main()

--- a/volunteer_app/register.py
+++ b/volunteer_app/register.py
@@ -1,0 +1,49 @@
+import csv
+import os
+
+CSV_FILE = os.path.join(os.path.dirname(__file__), 'volunteers.csv')
+
+FIELDNAMES = ['name', 'email', 'phone']
+
+def add_volunteer():
+    name = input('Name: ').strip()
+    email = input('Email: ').strip()
+    phone = input('Phone: ').strip()
+    write_header = not os.path.exists(CSV_FILE)
+    with open(CSV_FILE, 'a', newline='') as csvfile:
+        writer = csv.DictWriter(csvfile, fieldnames=FIELDNAMES)
+        if write_header:
+            writer.writeheader()
+        writer.writerow({'name': name, 'email': email, 'phone': phone})
+    print('Volunteer registered.')
+
+
+def list_volunteers():
+    if not os.path.exists(CSV_FILE):
+        print('No volunteers registered yet.')
+        return
+    with open(CSV_FILE, newline='') as csvfile:
+        reader = csv.DictReader(csvfile)
+        for i, row in enumerate(reader, 1):
+            print(f"{i}. {row['name']} - {row['email']} - {row['phone']}")
+
+
+def main():
+    while True:
+        print('\nVolunteer Registration')
+        print('1. Add volunteer')
+        print('2. List volunteers')
+        print('3. Exit')
+        choice = input('Choose an option: ').strip()
+        if choice == '1':
+            add_volunteer()
+        elif choice == '2':
+            list_volunteers()
+        elif choice == '3':
+            break
+        else:
+            print('Invalid choice.')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add a simple CLI application to register volunteers
- document how to use the app in the README
- create OTP-based volunteer system with admin and participant flows
- implement sqlite backend and basic audit trail
- add tests for database initialization and OTP generation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688bfe9a1ff8833382dcff0e8fd6cc39