### PR TITLE
Add basic document control script with reward points

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,15 @@ Initialize the database and start the application:
 ```bash
 python3 -m volunteer_app.main
 ```
+
+## Document Control System
+
+For a minimal digital document control workflow with simple reward points, use
+`volunteer_app/doc_control.py`.
+
+```bash
+python3 volunteer_app/doc_control.py
+```
+
+The script lets you register documents with a generated unique code, list the
+stored records and awards a small point value for each registration.

--- a/tests/test_doc_control.py
+++ b/tests/test_doc_control.py
@@ -1,0 +1,30 @@
+import sys, pathlib; sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+from volunteer_app import doc_control
+
+
+def test_generate_doc_id_length():
+    doc_id = doc_control.generate_doc_id()
+    assert len(doc_id) == 8
+    int(doc_id, 16)  # should be hex
+
+
+def test_register_document(tmp_path, monkeypatch):
+    tmp_file = tmp_path / 'docs.csv'
+    monkeypatch.setattr(doc_control, 'DOCS_FILE', str(tmp_file))
+    doc_id, reward = doc_control.register_document('Contract', 'confidential', reward=5)
+    assert reward == 5
+    assert len(doc_id) == 8
+    assert tmp_file.exists()
+    lines = tmp_file.read_text().strip().splitlines()
+    assert len(lines) == 2  # header + row
+
+
+def test_list_documents(tmp_path, monkeypatch):
+    tmp_file = tmp_path / 'docs.csv'
+    monkeypatch.setattr(doc_control, 'DOCS_FILE', str(tmp_file))
+    doc_control.register_document('Letter', 'official', reward=3)
+    docs = doc_control.list_documents()
+    assert len(docs) == 1
+    assert docs[0]['title'] == 'Letter'
+    assert docs[0]['category'] == 'official'
+    assert docs[0]['reward'] == 3

--- a/volunteer_app/doc_control.py
+++ b/volunteer_app/doc_control.py
@@ -1,0 +1,84 @@
+"""Simple digital document control system with voucher reward."""
+
+import csv
+import os
+import uuid
+
+DOCS_FILE = os.path.join(os.path.dirname(__file__), 'documents.csv')
+FIELDNAMES = ['id', 'title', 'category', 'reward']
+
+
+def generate_doc_id() -> str:
+    """Return a short unique id for a document."""
+    return uuid.uuid4().hex[:8]
+
+
+def register_document(title: str, category: str, reward: int = 10):
+    """Register a document and award a fixed reward.
+
+    Parameters
+    ----------
+    title: str
+        Title or name of the document.
+    category: str
+        Classification of the document.
+    reward: int, optional
+        Reward points given for registering the document.
+
+    Returns
+    -------
+    tuple
+        The generated document id and reward points awarded.
+    """
+    doc_id = generate_doc_id()
+    write_header = not os.path.exists(DOCS_FILE)
+    with open(DOCS_FILE, 'a', newline='') as csvfile:
+        writer = csv.DictWriter(csvfile, fieldnames=FIELDNAMES)
+        if write_header:
+            writer.writeheader()
+        writer.writerow({'id': doc_id, 'title': title, 'category': category, 'reward': reward})
+    return doc_id, reward
+
+
+def list_documents():
+    """Return a list of registered documents with numeric rewards."""
+    if not os.path.exists(DOCS_FILE):
+        return []
+    with open(DOCS_FILE, newline='') as csvfile:
+        reader = csv.DictReader(csvfile)
+        docs = []
+        for row in reader:
+            try:
+                row['reward'] = int(row['reward'])
+            except (KeyError, ValueError):
+                pass
+            docs.append(row)
+        return docs
+
+
+def main():
+    while True:
+        print('\nDocument Control')
+        print('1. Register document')
+        print('2. List documents')
+        print('3. Exit')
+        choice = input('Choose an option: ').strip()
+        if choice == '1':
+            title = input('Title: ').strip()
+            category = input('Category: ').strip()
+            doc_id, reward = register_document(title, category)
+            print(f'Document {doc_id} registered. Reward: {reward} points')
+        elif choice == '2':
+            docs = list_documents()
+            if not docs:
+                print('No documents registered yet.')
+            for d in docs:
+                print(f"{d['id']} - {d['title']} ({d['category']}) : {d['reward']} points")
+        elif choice == '3':
+            break
+        else:
+            print('Invalid choice')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add a document control CLI script that registers documents with a generated id and awards points
- document the new script in README
- test ID generation and document registration
- parse reward values when listing documents and test listing functionality

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e5fb2aa848333bb55f0c1ff23412b